### PR TITLE
Only allow Facebook ButtonMessages with up to three buttons

### DIFF
--- a/bottery/platform/messenger/message.py
+++ b/bottery/platform/messenger/message.py
@@ -9,9 +9,18 @@ class Button:
     payload = attr.ib()
 
 
+
 @attr.s
 class ButtonMessage(Message):
     buttons = attr.ib(factory=list)
+
+    @buttons.validator
+    def validate_buttons(self, attribute, value):
+        if len(value) > 3:
+            docs_url = ("https://developers.facebook.com/docs/"
+                        "messenger-platform/send-messages/template/generic")
+            raise ValueError("Facebook only allows up to three buttons. "
+                             "Check {} for details".format(docs_url))
 
     @property
     def datetime(self):


### PR DESCRIPTION
Facebook's API [limits the number of buttons in a template message to three](https://developers.facebook.com/docs/messenger-platform/send-messages/template/generic). This PR makes sure Bottery raises an error when the user tries to send more then three buttons.